### PR TITLE
Enable viewing past results from history list

### DIFF
--- a/index.html
+++ b/index.html
@@ -829,6 +829,29 @@
             startButton.disabled = true;
         }
 
+        function showHistoryEntry(entry) {
+            const option = Array.from(districtSelect.options).find(opt => opt.textContent === entry.district);
+            if (!option) return;
+            selectedDistrict = option.value;
+            districtSelect.value = selectedDistrict;
+            userAnswers = entry.answers;
+
+            districtSelection.classList.add('hidden');
+            quizSection.classList.add('hidden');
+            resultsSection.classList.remove('hidden');
+
+            const candidates = candidatesData[selectedDistrict] || [];
+            const matches = calculateMatches(candidates);
+            const partyMatches = calculatePartyMatches();
+
+            displayResults(matches);
+            displayPartyResults(partyMatches);
+            displayUserAnswers();
+            createChart(matches);
+
+            resultsSection.scrollIntoView({behavior: 'smooth'});
+        }
+
         function saveToHistory() {
             const history = JSON.parse(localStorage.getItem('voteCompassHistory') || '[]');
             const districtName = document.querySelector(`#districtSelect option[value="${selectedDistrict}"]`).textContent;
@@ -856,7 +879,7 @@
             }
             
             historyList.innerHTML = history.map(entry => `
-                <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
+                <div class="flex justify-between items-center p-3 bg-gray-50 rounded-lg cursor-pointer history-item">
                     <div>
                         <span class="font-medium">${entry.district}</span>
                         <span class="text-sm text-gray-500 ml-2">${entry.date}</span>
@@ -864,6 +887,11 @@
                     <i class="fas fa-check-circle text-green-500"></i>
                 </div>
             `).join('');
+
+            history.forEach((entry, index) => {
+                const item = historyList.children[index];
+                item.addEventListener('click', () => showHistoryEntry(entry));
+            });
         }
 
         // PWA Service Worker


### PR DESCRIPTION
## Summary
- enable clicking history entries to show stored results

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c2fa02884832e8a6140234cf01700